### PR TITLE
Enable running app inside of Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM node:12.16.1
 
-RUN apt-get update && apt-get install -y libnss3-dev libgtk-3-0 libxss1 libasound2 libcanberra-gtk-module libcanberra-gtk3-module
+RUN apt-get update && apt-get install -y libnss3-dev libgtk-3-0 libxss1 libasound2 libcanberra-gtk-module libcanberra-gtk3-module libgl1-mesa-glx libgl1-mesa-dri mesa-utils mesa-utils-extra sudo
 
 WORKDIR /app/
 
 # Give the node user (added by the base image) access to the working directory.
 RUN chown -R node /app
 
+RUN usermod -a -G video node
+RUN usermod -a -G sudo node
 USER node
 
 COPY --chown=node package.json /app/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,12 @@ services:
     environment:
       - DISPLAY
     network_mode: 'host'
+    ipc: host # https://github.com/cypress-io/cypress/issues/350
+    privileged: true
     volumes:
       - .:/app
       - /app/node_modules # prevents the container from polluting local directory
       - "$HOME/.Xauthority:/home/node/.Xauthority:rw" # Share the X Server with the container
-    command: 'tail -f /dev/null'
+      - "/tmp/.X11-unix:/tmp/.X11-unix:rw"
+      - /var/run/dbus:/var/run/dbus
+    command: 'tail -F anything'


### PR DESCRIPTION
Enable running this electron app inside Docker container. 
Relevant links: 
[Using GUI's with Docker](http://wiki.ros.org/docker/Tutorials/GUI)
[How docker replaced my virtual machines and chroots](https://gernotklingler.com/blog/docker-replaced-virtual-machines-chroots/)
[Docker crashes when render process eats up too much memory](https://github.com/cypress-io/cypress/issues/350)